### PR TITLE
CCAP-141: Permit access to the microservice from the webapp only.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ crash.*.log
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
-.env
+*.env
+!sample.env
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ the equivalent version of [Terraform].
 To run the configurations locally, you will need to have AWS credentials loaded
 from [Identity Center][identity-center], and installed OpenTofu.
 
-Navigate to the configuration you would like to plan or apply, then run the
-plan command to see what changes will be made:
+Navigate to the configuration you would like to plan or apply. Copy the
+`sample.env` file to `.env`, and set the appropriate values. Make sure this file
+is loaded into your environment. This can be done automatically through various
+shell tools (such as [Oh My Zsh][omz]), or manually by running `source .env`.
+
+With the environment variables loaded, run the plan command to see what changes
+will be made:
 
 ```bash
 cd tofu/config/staging # Replace with the appropriate configuration

--- a/tofu/config/staging/.terraform.lock.hcl
+++ b/tofu/config/staging/.terraform.lock.hcl
@@ -2,19 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/hashicorp/aws" {
-  version     = "5.50.0"
+  version     = "5.55.0"
   constraints = ">= 3.29.0, >= 3.74.0, >= 5.30.0, >= 5.37.0, >= 5.44.0, ~> 5.44, >= 5.46.0"
   hashes = [
-    "h1:ZN7MLKklx+LTYZvRerNw5O2qHA913Xg9eQW99uqfbI8=",
-    "zh:17345c5dee93b49009c7941b1e47bb6fe94376e2d0ffc83bfd80f75c9857e2cd",
-    "zh:2ed80ee2aa5db4fe29700e5488cd67409331a5a586102511a512c34e0f31bc38",
-    "zh:30cbf46810151a2f587bbeb4172e3534186e4cfae03d4d91a90dc4d3b304acb4",
-    "zh:449b4562b8530e2d3e7555d3ed9bc0a5a9ead1067784e86572b26b98f87a073f",
-    "zh:7a853b8ae08304c8d4e8d37a607e21d1a06e0956b3aef9e52b569dc556438d90",
-    "zh:8a6923372241b0b4aa58631e5a9487b6c8eebd456d001422f0b05f707ec29744",
-    "zh:90e1b8c7a51a97d2cae255b225f9260bf75bff72c13b791453fbed8f2d2ac729",
-    "zh:a0b4f62de237913e22387630668a79754fb23c231ea8629615722287cf5e58c5",
-    "zh:c4632d2dad5ec905f625b75b80d996047967c1d2105c11daad8cbc69972fdeda",
-    "zh:ce8866ce789f27e97b890dd8a82dea101deb66daf2e651ed387584aecc51d8b4",
+    "h1:dYJYSbcEuN2mjUdwR8sXmZKDfcUrNjhRxpDers67tZ4=",
+    "zh:5f3b59c7c66ee0cd2de72e3cece150bc6c15d4b5cef7f477b5edc8e2cf4a1a4d",
+    "zh:83c4869bd79df190290462531912c71ac44378bce006c0e0642b7bf7a0515d25",
+    "zh:87bcf0a21810867c0d30e526b9f9e78bc4ac503f3eb699de1d31c3d59d01006e",
+    "zh:c6a941a9c3fd3a91e2cb6a0987838659ed002cf0a0bbcb4b9471415cdf5c3540",
+    "zh:c6abf77975feb99a2fc5ff86477d7d173a10d07daa4cebbcb46944aa76ce2754",
+    "zh:c7d215071cd6afcb6d11befd95214cda9013402ed739707fcdbc55928b0a1d5d",
+    "zh:d21cf10a39552e6e2df4f55c6d7426befdc8a94d1d471b9eccf567ccfbd42497",
+    "zh:decd64542e1183fc32227dd1faaca79926035ca8d332b085d9ca8874432ad4f3",
+    "zh:e5677331ebeee0ae8cbca33323c6aff401875f41e4ce1d7a2afefae5752d27d0",
+    "zh:fb932872eab2e6d96332ef306c6562ca721ca78164fad109945de48f50465d25",
   ]
 }

--- a/tofu/config/staging/main.tf
+++ b/tofu/config/staging/main.tf
@@ -28,7 +28,7 @@ module "logging" {
 # environment, we'll use a single NAT gateway to reduce costs.
 module "vpc" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/codeforamerica/tofu-modules?ref=vpc-peering/aws/vpc"
+  source = "github.com/codeforamerica/tofu-modules/aws/vpc"
 
   cidr               = "10.0.20.0/22"
   project            = "illinois-getchildcare"
@@ -52,7 +52,7 @@ module "vpc" {
 # Deploy the Document Transfer service to a Fargate cluster.
 module "document_transfer" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/codeforamerica/tofu-modules?ref=vpc-peering/aws/fargate_service"
+  source = "github.com/codeforamerica/tofu-modules/aws/fargate_service"
 
   project                = "illinois-getchildcare"
   project_short          = "il-gcc"

--- a/tofu/config/staging/main.tf
+++ b/tofu/config/staging/main.tf
@@ -28,7 +28,7 @@ module "logging" {
 # environment, we'll use a single NAT gateway to reduce costs.
 module "vpc" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/codeforamerica/tofu-modules/aws/vpc"
+  source = "github.com/codeforamerica/tofu-modules?ref=vpc-peering/aws/vpc"
 
   cidr               = "10.0.20.0/22"
   project            = "illinois-getchildcare"
@@ -38,25 +38,48 @@ module "vpc" {
 
   private_subnets = ["10.0.22.0/26", "10.0.22.64/26", "10.0.22.128/26"]
   public_subnets  = ["10.0.20.0/26", "10.0.20.64/26", "10.0.20.128/26"]
+
+  peers = {
+    "aptible" : {
+      account_id : "916150859591",
+      vpc_id : "vpc-041ed50bbc0467be5",
+      region : "us-east-1",
+      cidr : "10.226.0.0/16"
+    }
+  }
 }
 
 # Deploy the Document Transfer service to a Fargate cluster.
 module "document_transfer" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/codeforamerica/tofu-modules/aws/fargate_service"
+  source = "github.com/codeforamerica/tofu-modules?ref=vpc-peering/aws/fargate_service"
 
-  project         = "illinois-getchildcare"
-  project_short   = "il-gcc"
-  environment     = "staging"
-  service         = "document-transfer"
-  service_short   = "doc-trans"
-  domain          = "staging.document-transfer.cfa.codes"
-  vpc_id          = module.vpc.vpc_id
-  private_subnets = module.vpc.private_subnets
-  public_subnets  = module.vpc.public_subnets
-  logging_key_id  = module.logging.kms_key_arn
-  container_port  = 3000
-  force_delete    = true
+  project                = "illinois-getchildcare"
+  project_short          = "il-gcc"
+  environment            = "staging"
+  service                = "document-transfer"
+  service_short          = "doc-trans"
+  domain                 = "staging.document-transfer.cfa.codes"
+  vpc_id                 = module.vpc.vpc_id
+  private_subnets        = module.vpc.private_subnets
+  public_subnets         = module.vpc.public_subnets
+  logging_key_id         = module.logging.kms_key_arn
+  container_port         = 3000
+  force_delete           = true
+  image_tags_mutable     = true
+  enable_execute_command = true
+
+  # Only allow access from the web application and its workers.
+  ingress_cidrs = ["10.226.0.0/16"]
+
+  environment_variables = {
+    RACK_ENV                    = "staging"
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318"
+  }
+}
+
+output "peer_ids" {
+  value = module.vpc.peer_ids
 }
 
 # Display commands to push the Docker image to ECR.

--- a/tofu/config/staging/sample.env
+++ b/tofu/config/staging/sample.env
@@ -1,0 +1,2 @@
+# Set the name of the aws profile for this config.
+export AWS_PROFILE=


### PR DESCRIPTION
#### 🔗 Jira ticket

CCAP-141

#### ✍️ Description

- Moved the document transfer service to an internal ALB.
- Restrict access to the CIDR range of the Aptible VPC.

#### 📷 Design reference

[Tech spec](https://www.notion.so/cfa/Tech-Spec-Document-Transfer-Service-d89aa25d41e447b3920ff07ab03ce7c1?pvs=4)

#### 🧪 Testing instructions

- [ ] Ensure that https://staging.document-transfer.cfa.codes/health can not be accessed from the Internet

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria

#### 📓 Additional notes

These changes have already been applied (necessary to complete the peering connection with Aptible. Below is a diff, show what would be removed if these changes were rolled back:

```text
OpenTofu used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy
-/+ destroy and then create replacement
+/- create replacement and then destroy

OpenTofu will perform the following actions:

  # module.vpc.aws_route.peer[aptible] will be destroyed
  # (because key [aptible] is not in for_each map)
  - resource aws_route peer {
      - destination_cidr_block    = 10.226.0.0/16 -> null
      - id                        = r-rtb-0d07fbe3b003de612368033544 -> null
      - origin                    = CreateRoute -> null
      - route_table_id            = rtb-0d07fbe3b003de612 -> null
      - state                     = active -> null
      - vpc_peering_connection_id = pcx-0abf9e62533f46ca6 -> null
    }

  # module.vpc.aws_vpc_peering_connection.peer[aptible] will be destroyed
  # (because key [aptible] is not in for_each map)
  - resource aws_vpc_peering_connection peer {
      - accept_status = active -> null
      - id            = pcx-0abf9e62533f46ca6 -> null
      - peer_owner_id = 916150859591 -> null
      - peer_region   = us-east-1 -> null
      - peer_vpc_id   = vpc-041ed50bbc0467be5 -> null
      - tags          = {
          - Name = illinois-getchildcare-staging-aptible
        } -> null
      - tags_all      = {
          - Name        = illinois-getchildcare-staging-aptible
          - environment = staging
          - project     = illinois-getchildcare
          - tofu        = true
        } -> null
      - vpc_id        = vpc-0c4c542a315b[431](https://github.com/codeforamerica/il-gcc-infra/actions/runs/9614540058/job/26519649368#step:7:432)d2 -> null

      - requester {
          - allow_remote_vpc_dns_resolution = false -> null
        }
    }

  # module.document_transfer.module.ecr.aws_ecr_repository.this[0] will be updated in-place
  ~ resource aws_ecr_repository this {
        id                   = illinois-getchildcare-staging-document-transfer
      ~ image_tag_mutability = MUTABLE -> IMMUTABLE
        name                 = illinois-getchildcare-staging-document-transfer
        tags                 = {}
        # (4 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.document_transfer.module.endpoint_security_group.aws_security_group_rule.ingress_rules[0] must be replaced
-/+ resource aws_security_group_rule ingress_rules {
      ~ cidr_blocks              = [ # forces replacement
            10.0.20.0/22,
          - 10.226.0.0/16,
        ]
      ~ id                       = sgrule-1972381386 -> (known after apply)
      + security_group_rule_id   = (known after apply)
      + source_security_group_id = (known after apply)
        # (9 unchanged attributes hidden)
    }

  # module.document_transfer.module.endpoint_security_group.aws_security_group_rule.ingress_rules[1] must be replaced
-/+ resource aws_security_group_rule ingress_rules {
      ~ cidr_blocks              = [ # forces replacement
            10.0.20.0/22,
          - 10.226.0.0/16,
        ]
      ~ id                       = sgrule-40105728 -> (known after apply)
      + security_group_rule_id   = (known after apply)
      + source_security_group_id = (known after apply)
        # (9 unchanged attributes hidden)
    }

  # module.document_transfer.module.ecs_service.module.fargate.aws_ecs_service.main[0] will be updated in-place
  ~ resource aws_ecs_service main {
      ~ enable_execute_command             = true -> false
        id                                 = arn:aws:ecs:us-east-1:891377151751:service/illinois-getchildcare-staging-document-transfer/illinois-getchildcare-staging-document-transfer
        name                               = illinois-getchildcare-staging-document-transfer
        tags                               = {}
      ~ task_definition                    = arn:aws:ecs:us-east-1:891377151751:task-definition/illinois-getchildcare-staging-document-transfer:37 -> (known after apply)
        # (14 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.document_transfer.module.ecs_service.module.fargate.module.task.aws_ecs_task_definition.main[0] must be replaced
+/- resource aws_ecs_task_definition main {
      ~ arn                      = arn:aws:ecs:us-east-1:891377151751:task-definition/illinois-getchildcare-staging-document-transfer:37 -> (known after apply)
      ~ arn_without_revision     = arn:aws:ecs:us-east-1:891377151751:task-definition/illinois-getchildcare-staging-document-transfer -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  - environment       = [
                      - {
                          - name  = OTEL_EXPORTER_OTLP_ENDPOINT
                          - value = http://localhost:4318
                        },
                      - {
                          - name  = RACK_ENV
                          - value = staging
                        },
                      - {
                          - name  = STATSD_ENV
                          - value = staging
                        },
                    ]
                  - mountPoints       = []
                    name              = illinois-getchildcare-staging-document-transfer
                  ~ portMappings      = [
                      ~ {
                          - hostPort      = 3000
                          - protocol      = tcp
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  - systemControls    = []
                  - volumesFrom       = []
                    # (7 unchanged attributes hidden)
                },
              ~ {
                  - mountPoints      = []
                    name             = otel-collector
                  - portMappings     = []
                  - systemControls   = []
                  - volumesFrom      = []
                    # (7 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ id                       = illinois-getchildcare-staging-document-transfer -> (known after apply)
      ~ revision                 = 37 -> (known after apply)
      - tags                     = {} -> null
        # (10 unchanged attributes hidden)
    }

Plan: 3 to add, 2 to change, 5 to destroy.

Changes to Outputs:
  - peer_ids                      = [
      - pcx-0abf9e62[533](https://github.com/codeforamerica/il-gcc-infra/actions/runs/9614540058/job/26519649368#step:7:534)f46ca6,
    ] -> null
```
