### PR TITLE
Use env.config instead of inputs.config in tofu apply step of deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,5 +48,5 @@ jobs:
       # TODO: Add a manual approval step here. For now, we'll use GitHub
       # Actions' environment protection feature for sensitive environments.
       - name: Apply changes
-        working-directory: ./tofu/config/${{ inputs.config }}
+        working-directory: ./tofu/config/${{ env.CONFIG }}
         run: tofu apply --auto-approve


### PR DESCRIPTION
#### 🔗 Jira ticket

CCAP-690

#### ✍️ Description

Fixes an issue where inputs was not available in the apply step when running the deploy workflow from another repo.