### PR TITLE
Remove AWS credentials from app service

### DIFF
--- a/tofu/modules/il_gcc_application/main.tf
+++ b/tofu/modules/il_gcc_application/main.tf
@@ -230,9 +230,6 @@ module "service" {
     NO_PROVIDER_RESPONSE_DELAY               = "${module.secrets.secrets["il-gcc"].secret_arn}:no_provider_response_delay"
     ALLOW_PDF_MODIFICATION                   = "${module.secrets.secrets["il-gcc"].secret_arn}:allow_pdf_modification"
     RESOURCE_ORG_EMAILS                      = "${module.secrets.secrets["il-gcc"].secret_arn}:resource_org_emails"
-    AWS_REGION                               = "${module.secrets.secrets["aws"].secret_arn}:aws_region"
-    AWS_SECRET_KEY                           = "${module.secrets.secrets["aws"].secret_arn}:aws_secret_key"
-    AWS_ACCESS_KEY                           = "${module.secrets.secrets["aws"].secret_arn}:aws_access_key"
   }
 }
 


### PR DESCRIPTION
#### 🔗 Jira ticket

CCAP-1189

#### ✍️ Description

Removes AWS credential secrets in favor of AWS ECS Container Credentials configuration: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html (see step 5)
